### PR TITLE
update setup.py to add lxml as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name='nyaapy',
       install_requires=[
             "requests",
             "beautifulsoup4",
+            "lxml",
       ],
       url='https://github.com/juanjosalvador/nyaapy',
       long_description=long_desc,


### PR DESCRIPTION
Fixes error

```
File "xxxxx/NyaaPy/utils.py", line 2, in <module>
  from lxml import etree
ModuleNotFoundError: No module named 'lxml'
```